### PR TITLE
add support for running as a daemon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - checkout
       - run:
           name: build binary
-          command: make build
+          command: make build/linux/pentagon
       - persist_to_workspace:
           root: .
           paths:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/vimeo/pentagon.svg?branch=master)](https://travis-ci.org/vimeo/pentagon) [![GoDoc](https://godoc.org/github.com/vimeo/pentagon?status.svg)](https://godoc.org/github.com/vimeo/pentagon) [![Go Report Card](https://goreportcard.com/badge/github.com/vimeo/pentagon)](https://goreportcard.com/report/github.com/vimeo/pentagon) 
+
 
 # Pentagon
 Pentagon is a small application designed to run as a Kubernetes CronJob to periodically copy secrets stored in [Vault](https://www.vaultproject.io) into equivalent [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/), keeping them synchronized.  Naturally, this should be used with care as "standard" Kubernetes Secrets are simply obfuscated as base64-encoded strings.  However, one can and should use more secure methods of securing secrets including Google's [KMS](https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets) and restricting roles and service accounts appropriately.
@@ -21,6 +21,8 @@ vault:
   tls: # optional [tls options](https://godoc.org/github.com/hashicorp/vault/api#TLSConfig)
 namespace: <kubernetes namespace for created secrets>
 label: <label value to set for the 'pentagon'-created secrets>
+daemon: false # if true, the process periodically refreshes secrets
+refresh: 15m # the refresh interval when running as a daemon
 mappings:
   # mappings from vault paths to kubernetes secret names
   - vaultPath: secret/data/vault-path

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package pentagon
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/vault/api"
 	"github.com/vimeo/pentagon/vault"
@@ -28,6 +29,13 @@ type Config struct {
 
 	// Mappings is a list of mappings.
 	Mappings []Mapping `yaml:"mappings"`
+
+	// Daemon sets the process to run as a daemon, refreshing secrets periodically
+	Daemon bool `yaml:"daemon"`
+
+	// RefreshInterval sets the interval that secrets should be refreshed when running
+	// as a daemon
+	RefreshInterval time.Duration `yaml:"refresh"`
 }
 
 // SetDefaults sets defaults for the Namespace and Label in case they're
@@ -52,6 +60,10 @@ func (c *Config) SetDefaults() {
 		if m.VaultEngineType == "" {
 			m.VaultEngineType = c.Vault.DefaultEngineType
 		}
+	}
+
+	if c.RefreshInterval == 0 {
+		c.RefreshInterval = time.Minute * 15
 	}
 }
 


### PR DESCRIPTION
when running as a daemon, the proecess with periodically refresh
the secrets from vault.  The refresh interval can be controlled via
the config.