### PR TITLE
implicitly detect secret types and set field accordingly

### DIFF
--- a/reflector.go
+++ b/reflector.go
@@ -118,12 +118,12 @@ func (r *Reflector) Reflect(mappings []Mapping) error {
 		}
 
 		// if the secret has ".dockercfg", use type "kubernetes.io/dockercfg"
-		if k8sSecretData[v1.DockerConfigKey] != "" {
+		if k8sSecretData[v1.DockerConfigKey] != nil {
 			newSecret.Type = v1.SecretTypeDockercfg
 		}
 
 		// same with .dockerconfigson
-		if k8sSecretData[v1.DockerConfigJsonKey] != "" {
+		if k8sSecretData[v1.DockerConfigJsonKey] != nil {
 			newSecret.Type = v1.SecretTypeDockerConfigJson
 		}
 

--- a/reflector.go
+++ b/reflector.go
@@ -114,7 +114,20 @@ func (r *Reflector) Reflect(mappings []Mapping) error {
 				},
 			},
 			Data: k8sSecretData,
+			Type: v1.SecretTypeOpaque,
 		}
+
+		// if the secret has ".dockercfg", use type "kubernetes.io/dockercfg"
+		if k8sSecretData[v1.DockerConfigKey] != "" {
+			newSecret.Type = v1.SecretTypeDockercfg
+		}
+
+		// same with .dockerconfigson
+		if k8sSecretData[v1.DockerConfigJsonKey] != "" {
+			newSecret.Type = v1.SecretTypeDockerConfigJson
+		}
+
+		// there are other types as needed. See https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#SecretTypeOpaque
 
 		if _, ok := secretsSet[mapping.SecretName]; ok {
 			// secret already exists, so we should update it


### PR DESCRIPTION
Very simply assumes the type of the secret based on the fields present. Needs no additional config to work.

Note: Updating a secret that already exists of the wrong type will fail. It must be manually destroyed and re-created. This is expected.